### PR TITLE
Fix the Jmeter master and slave image names

### DIFF
--- a/jmeter_master_deploy.yaml
+++ b/jmeter_master_deploy.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: jmmaster
-        image: kubernautslabs/jmeter-master:latest
+        image: kubernautslabs/jmeter_master:latest
         imagePullPolicy: IfNotPresent
         command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]

--- a/jmeter_slaves_deploy.yaml
+++ b/jmeter_slaves_deploy.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: jmslave
-        image: kubernautslabs/jmeter-slave:latest
+        image: kubernautslabs/jmeter_slave:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 1099


### PR DESCRIPTION
with the current config the default installation will failed unless we fixed the images name like below