### PR TITLE
Fix tag image 1.x for influxdb

### DIFF
--- a/jmeter_influxdb_deploy.yaml
+++ b/jmeter_influxdb_deploy.yaml
@@ -15,7 +15,7 @@ spec:
         app: influxdb-jmeter
     spec:
       containers:
-        - image: influxdb
+        - image: influxdb:1.8.4
           imagePullPolicy: IfNotPresent
           name: influxdb
           volumeMounts:

--- a/openshift/jmeter_influxdb_deploy.yaml
+++ b/openshift/jmeter_influxdb_deploy.yaml
@@ -15,7 +15,7 @@ spec:
         app: influxdb-jmeter
     spec:
       containers:
-        - image: influxdb
+        - image: influxdb:1.8.4
           name: influxdb
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
Influxdb pull lasted version (is 2.x) then an error occurred running _./dashboard_:
```
"Error: unknown shorthand flag: 'e' in -execute See 'influx -h' for help"
``` 
The downgrade was successful.